### PR TITLE
Dataset switch fix

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -283,6 +283,10 @@ server <- function(input, output, session) {
                     scroller = TRUE)
     )
   })
+  proxy <- dataTableProxy("metadata")
+  observe({
+    replaceData(proxy, colData(dataset()[["sce"]]))
+  })
   
   # Source code.
   output$source.code <- renderUI({

--- a/app/app.R
+++ b/app/app.R
@@ -283,6 +283,9 @@ server <- function(input, output, session) {
                     scroller = TRUE)
     )
   })
+  
+  # Update metadata table with new values on dataset switch so that any previous filter is not carried over
+  # in terms of samples removed from plots.
   proxy <- dataTableProxy("metadata")
   observe({
     replaceData(proxy, colData(dataset()[["sce"]]))


### PR DESCRIPTION
Fixes a dataset switching issue whereby applying a filter to the metadata table, then switching datasets would carry over the row indexing filters...resulting in obscure errors and missing samples from plots.